### PR TITLE
Correct parameter alias names

### DIFF
--- a/Auvik.Api/Data/DeviceLifecycleAttributes.cs
+++ b/Auvik.Api/Data/DeviceLifecycleAttributes.cs
@@ -150,7 +150,13 @@ namespace Auvik.Api.Data
 			/// Enum Empty for "empty"
 			/// </summary>
 			[EnumMember(Value = "empty")]
-			Empty
+			Empty,
+
+            /// <summary>
+            /// Enum Empty for "unknown"
+            /// </summary>
+            [EnumMember(Value = "unknown")]
+            Unknown,
 		}
 
 		/// <summary>
@@ -195,7 +201,13 @@ namespace Auvik.Api.Data
 			/// Enum Empty for "empty"
 			/// </summary>
 			[EnumMember(Value = "empty")]
-			Empty
+			Empty,
+
+            /// <summary>
+            /// Enum Empty for "unknown"
+            /// </summary>
+            [EnumMember(Value = "unknown")]
+            Unknown,
 		}
 
 		/// <summary>

--- a/Auvik.Api/Interfaces/IAlertHistory.cs
+++ b/Auvik.Api/Interfaces/IAlertHistory.cs
@@ -33,19 +33,19 @@ namespace Auvik.Api.Interfaces
 		/// <returns>Task of AlertHistoryInfoReadMultiple</returns>
 		[Get("/v1/alert/history/info")]
 		Task<AlertHistoryInfoReadMultiple> ReadMultipleAlertInfo(
-			[AliasAs("filter_alertSpecificationId")] string filter_alertSpecificationId = null,
-			[AliasAs("filter_severity")] string filter_severity = null,
-			[AliasAs("filter_status")] string filter_status = null,
-			[AliasAs("filter_entityId")] string filter_entityId = null,
-			[AliasAs("filter_dismissed")] bool? filter_dismissed = null,
-			[AliasAs("filter_dispatched")] bool? filter_dispatched = null,
-			[AliasAs("filter_detectedTimeAfter")] bool? filter_detectedTimeAfter = null,
-			[AliasAs("filter_detectedTimeBefore")] bool? filter_detectedTimeBefore = null,
+			[AliasAs("filter[alertSpecificationId]")] string filter_alertSpecificationId = null,
+			[AliasAs("filter[severity]")] string filter_severity = null,
+			[AliasAs("filter[status]")] string filter_status = null,
+			[AliasAs("filter[entityId]")] string filter_entityId = null,
+			[AliasAs("filter[dismissed]")] bool? filter_dismissed = null,
+			[AliasAs("filter[dispatched]")] bool? filter_dispatched = null,
+			[AliasAs("filter[detectedTimeAfter]")] bool? filter_detectedTimeAfter = null,
+			[AliasAs("filter[detectedTimeBefore]")] bool? filter_detectedTimeBefore = null,
 			[AliasAs("tenants")] string tenants = null,
-			[AliasAs("page_first")] decimal? page_first = null,
-			[AliasAs("page_after")] string page_after = null,
-			[AliasAs("page_last")] decimal? page_last = null,
-			[AliasAs("page_before")] string page_before = null,
+			[AliasAs("page[first]")] decimal? page_first = null,
+			[AliasAs("page[after]")] string page_after = null,
+			[AliasAs("page[last]")] decimal? page_last = null,
+			[AliasAs("page[before]")] string page_before = null,
 			CancellationToken? cancellationToken = null
 			);
 

--- a/Auvik.Api/Interfaces/IComponent.cs
+++ b/Auvik.Api/Interfaces/IComponent.cs
@@ -31,15 +31,15 @@ namespace Auvik.Api.Interfaces
 		[Get("/v1/inventory/component/info")]
 		Task<ComponentInfoReadMultiple> ReadMultipleComponentInfo(
 			[Header("UserAgent")] string userAgent,
-			[AliasAs("filter_modifiedAfter")] string filter_modifiedAfter = null,
-			[AliasAs("filter_deviceId")] string filter_deviceId = null,
-			[AliasAs("filter_deviceName")] string filter_deviceName = null,
-			[AliasAs("filter_currentStatus")] string filter_currentStatus = null,
+			[AliasAs("filter[modifiedAfter]")] string filter_modifiedAfter = null,
+			[AliasAs("filter[deviceId]")] string filter_deviceId = null,
+			[AliasAs("filter[deviceName]")] string filter_deviceName = null,
+			[AliasAs("filter[currentStatus]")] string filter_currentStatus = null,
 			[AliasAs("tenants")] string tenants = null,
-			[AliasAs("page_first")] decimal? page_first = null,
-			[AliasAs("page_after")] string page_after = null,
-			[AliasAs("page_last")] decimal? page_last = null,
-			[AliasAs("page_before")] string page_before = null,
+			[AliasAs("page[first]")] decimal? page_first = null,
+			[AliasAs("page[after]")] string page_after = null,
+			[AliasAs("page[last]")] decimal? page_last = null,
+			[AliasAs("page[before]")] string page_before = null,
 			CancellationToken? cancellationToken = null
 		);
 

--- a/Auvik.Api/Interfaces/IConfiguration.cs
+++ b/Auvik.Api/Interfaces/IConfiguration.cs
@@ -29,15 +29,15 @@ namespace Auvik.Api.Interfaces
 		/// <returns>Task of ConfigReadMultiple</returns>
 		[Get("/v1/inventory/configuration")]
 		Task<ConfigReadMultiple> ReadMultipleConfigurations(
-			[AliasAs("filter_deviceId")] string filter_deviceId = null,
-			[AliasAs("filter_backupTimeAfter")] string filter_backupTimeAfter = null,
-			[AliasAs("filter_backupTimeBefore")] string filter_backupTimeBefore = null,
-			[AliasAs("filter_isRunning")] bool? filter_isRunning = null,
+			[AliasAs("filter[deviceId]")] string filter_deviceId = null,
+			[AliasAs("filter[backupTimeAfter]")] string filter_backupTimeAfter = null,
+			[AliasAs("filter[backupTimeBefore]")] string filter_backupTimeBefore = null,
+			[AliasAs("filter[isRunning]")] bool? filter_isRunning = null,
 			[AliasAs("tenants")] string tenants = null,
-			[AliasAs("page_first")] decimal? page_first = null,
-			[AliasAs("page_after")] string page_after = null,
-			[AliasAs("page_last")] decimal? page_last = null,
-			[AliasAs("page_before")] string page_before = null,
+			[AliasAs("page[first]")] decimal? page_first = null,
+			[AliasAs("page[after]")] string page_after = null,
+			[AliasAs("page[last]")] decimal? page_last = null,
+			[AliasAs("page[before]")] string page_before = null,
 			CancellationToken? cancellationToken = null
 		);
 

--- a/Auvik.Api/Interfaces/IDevice.cs
+++ b/Auvik.Api/Interfaces/IDevice.cs
@@ -31,17 +31,17 @@ namespace Auvik.Api.Interfaces
 		/// <returns>Task of DeviceDetailsReadMultiple</returns>
 		[Get("/v1/inventory/device/detail")]
 		Task<DeviceDetailsReadMultiple> ReadMultipleDeviceDetails(
-			[AliasAs("filter_manageStatus")] bool? filter_manageStatus = null,
-			[AliasAs("filter_discoverySNMP")] string filter_discoverySNMP = null,
-			[AliasAs("filter_discoveryWMI")] string filter_discoveryWMI = null,
-			[AliasAs("filter_discoveryLogin")] string filter_discoveryLogin = null,
-			[AliasAs("filter_discoveryVMware")] string filter_discoveryVMware = null,
-			[AliasAs("filter_trafficInsightsStatus")] string filter_trafficInsightsStatus = null,
+			[AliasAs("filter[manageStatus]")] bool? filter_manageStatus = null,
+			[AliasAs("filter[discoverySNMP]")] string filter_discoverySNMP = null,
+			[AliasAs("filter[discoveryWMI]")] string filter_discoveryWMI = null,
+			[AliasAs("filter[discoveryLogin]")] string filter_discoveryLogin = null,
+			[AliasAs("filter[discoveryVMware]")] string filter_discoveryVMware = null,
+			[AliasAs("filter[trafficInsightsStatus]")] string filter_trafficInsightsStatus = null,
 			[AliasAs("tenants")] string tenants = null,
-			[AliasAs("page_first")] decimal? page_first = null,
-			[AliasAs("page_after")] string page_after = null,
-			[AliasAs("page_last")] decimal? page_last = null,
-			[AliasAs("page_before")] string page_before = null,
+			[AliasAs("page[first]")] decimal? page_first = null,
+			[AliasAs("page[after]")] string page_after = null,
+			[AliasAs("page[last]")] decimal? page_last = null,
+			[AliasAs("page[before]")] string page_before = null,
 			CancellationToken? cancellationToken = null
 		);
 
@@ -63,14 +63,14 @@ namespace Auvik.Api.Interfaces
 		/// <returns>Task of DeviceDetailsExtendedReadMultiple</returns>
 		[Get("/v1/inventory/device/detail/extended")]
 		Task<DeviceDetailsExtendedReadMultiple> ReadMultipleDeviceExtendedDetail(
-			[AliasAs("filter_deviceType")] string filter_deviceType,
-			[AliasAs("filter_modifiedAfter")] string filter_modifiedAfter = null,
-			[AliasAs("filter_notSeenSince")] string filter_notSeenSince = null,
+			[AliasAs("filter[deviceType]")] string filter_deviceType,
+			[AliasAs("filter[modifiedAfter]")] string filter_modifiedAfter = null,
+			[AliasAs("filter[notSeenSince]")] string filter_notSeenSince = null,
 			[AliasAs("tenants")] string tenants = null,
-			[AliasAs("page_first")] decimal? page_first = null,
-			[AliasAs("page_after")] string page_after = null,
-			[AliasAs("page_last")] decimal? page_last = null,
-			[AliasAs("page_before")] string page_before = null,
+			[AliasAs("page[first]")] decimal? page_first = null,
+			[AliasAs("page[after]")] string page_after = null,
+			[AliasAs("page[last]")] decimal? page_last = null,
+			[AliasAs("page[before]")] string page_before = null,
 			CancellationToken? cancellationToken = null
 		);
 
@@ -98,20 +98,20 @@ namespace Auvik.Api.Interfaces
 		/// <returns>Task of DeviceInfoReadMultiple</returns>
 		[Get("/v1/inventory/device/info")]
 		Task<DeviceInfoReadMultiple> ReadMultipleDeviceInfo(
-			[AliasAs("filter_networks")] string filter_networks = null,
-			[AliasAs("filter_deviceType")] string filter_deviceType = null,
-			[AliasAs("filter_makeModel")] string filter_makeModel = null,
-			[AliasAs("filter_vendorName")] string filter_vendorName = null,
-			[AliasAs("filter_onlineStatus")] string filter_onlineStatus = null,
-			[AliasAs("filter_modifiedAfter")] string filter_modifiedAfter = null,
-			[AliasAs("filter_notSeenSince")] string filter_notSeenSince = null,
+			[AliasAs("filter[networks]")] string filter_networks = null,
+			[AliasAs("filter[deviceType]")] string filter_deviceType = null,
+			[AliasAs("filter[makeModel]")] string filter_makeModel = null,
+			[AliasAs("filter[vendorName]")] string filter_vendorName = null,
+			[AliasAs("filter[onlineStatus]")] string filter_onlineStatus = null,
+			[AliasAs("filter[modifiedAfter]")] string filter_modifiedAfter = null,
+			[AliasAs("filter[notSeenSince]")] string filter_notSeenSince = null,
 			[AliasAs("tenants")] string tenants = null,
-			[AliasAs("page_first")] decimal? page_first = null,
-			[AliasAs("page_after")] string page_after = null,
-			[AliasAs("page_last")] decimal? page_last = null,
-			[AliasAs("page_before")] string page_before = null,
+			[AliasAs("page[first]")] decimal? page_first = null,
+			[AliasAs("page[after]")] string page_after = null,
+			[AliasAs("page[last]")] decimal? page_last = null,
+			[AliasAs("page[before]")] string page_before = null,
 			[AliasAs("include")] string include = null,
-			[AliasAs("fields_deviceDetail")] string fields_deviceDetail = null,
+			[AliasAs("fields[deviceDetail]")] string fields_deviceDetail = null,
 			CancellationToken? cancellationToken = null
 		);
 
@@ -134,15 +134,15 @@ namespace Auvik.Api.Interfaces
 		/// <returns>Task of DeviceLifecycleReadMultiple</returns>
 		[Get("/v1/inventory/device/lifecycle")]
 		Task<DeviceLifecycleReadMultiple> ReadMultipleDeviceLifecycle(
-			[AliasAs("filter_salesAvailability")] string filter_salesAvailability = null,
-			[AliasAs("filter_softwareMaintenanceStatus")] string filter_softwareMaintenanceStatus = null,
-			[AliasAs("filter_securitySoftwareMaintenanceStatus")] string filter_securitySoftwareMaintenanceStatus = null,
-			[AliasAs("filter_lastSupportStatus")] string filter_lastSupportStatus = null,
+			[AliasAs("filter[salesAvailability]")] string filter_salesAvailability = null,
+			[AliasAs("filter[softwareMaintenanceStatus]")] string filter_softwareMaintenanceStatus = null,
+			[AliasAs("filter[securitySoftwareMaintenanceStatus]")] string filter_securitySoftwareMaintenanceStatus = null,
+			[AliasAs("filter[lastSupportStatus]")] string filter_lastSupportStatus = null,
 			[AliasAs("tenants")] string tenants = null,
-			[AliasAs("page_first")] decimal? page_first = null,
-			[AliasAs("page_after")] string page_after = null,
-			[AliasAs("page_last")] decimal? page_last = null,
-			[AliasAs("page_before")] string page_before = null,
+			[AliasAs("page[first]")] decimal? page_first = null,
+			[AliasAs("page[after]")] string page_after = null,
+			[AliasAs("page[last]")] decimal? page_last = null,
+			[AliasAs("page[before]")] string page_before = null,
 			CancellationToken? cancellationToken = null
 		);
 
@@ -163,13 +163,13 @@ namespace Auvik.Api.Interfaces
 		/// <returns>Task of DeviceWarrantyReadMultiple</returns>
 		[Get("/v1/inventory/device/warranty")]
 		Task<DeviceWarrantyReadMultiple> ReadMultipleDeviceWarranty(
-			[AliasAs("filter_coveredUnderWarranty")] bool? filter_coveredUnderWarranty = null,
-			[AliasAs("filter_coveredUnderService")] bool? filter_coveredUnderService = null,
+			[AliasAs("filter[coveredUnderWarranty]")] bool? filter_coveredUnderWarranty = null,
+			[AliasAs("filter[coveredUnderService]")] bool? filter_coveredUnderService = null,
 			[AliasAs("tenants")] string tenants = null,
-			[AliasAs("page_first")] decimal? page_first = null,
-			[AliasAs("page_after")] string page_after = null,
-			[AliasAs("page_last")] decimal? page_last = null,
-			[AliasAs("page_before")] string page_before = null,
+			[AliasAs("page[first]")] decimal? page_first = null,
+			[AliasAs("page[after]")] string page_after = null,
+			[AliasAs("page[last]")] decimal? page_last = null,
+			[AliasAs("page[before]")] string page_before = null,
 			CancellationToken? cancellationToken = null
 		);
 
@@ -218,7 +218,7 @@ namespace Auvik.Api.Interfaces
 		Task<DeviceInfoReadSingle> ReadSingleDeviceInfo(
 			[AliasAs("id")] string id,
 			[AliasAs("include")] string include = null,
-			[AliasAs("fields_deviceDetail")] string fields_deviceDetail = null,
+			[AliasAs("fields[deviceDetail]")] string fields_deviceDetail = null,
 			CancellationToken? cancellationToken = null
 		);
 

--- a/Auvik.Api/Interfaces/IEntity.cs
+++ b/Auvik.Api/Interfaces/IEntity.cs
@@ -29,15 +29,15 @@ namespace Auvik.Api.Interfaces
 		/// <returns>Task of EntityAuditReadMultiple</returns>
 		[Get("/v1/inventory/entity/audit")]
 		Task<EntityAuditReadMultiple> ReadMultipleEntityAudit(
-			[AliasAs("filter_user")] string filter_user = null,
-			[AliasAs("filter_category")] string filter_category = null,
-			[AliasAs("filter_status")] string filter_status = null,
-			[AliasAs("filter_modifiedAfter")] string filter_modifiedAfter = null,
+			[AliasAs("filter[user]")] string filter_user = null,
+			[AliasAs("filter[category]")] string filter_category = null,
+			[AliasAs("filter[status]")] string filter_status = null,
+			[AliasAs("filter[modifiedAfter]")] string filter_modifiedAfter = null,
 			[AliasAs("tenants")] string tenants = null,
-			[AliasAs("page_first")] decimal? page_first = null,
-			[AliasAs("page_after")] string page_after = null,
-			[AliasAs("page_last")] decimal? page_last = null,
-			[AliasAs("page_before")] string page_before = null,
+			[AliasAs("page[first]")] decimal? page_first = null,
+			[AliasAs("page[after]")] string page_after = null,
+			[AliasAs("page[last]")] decimal? page_last = null,
+			[AliasAs("page[before]")] string page_before = null,
 			CancellationToken? cancellationToken = null
 		);
 
@@ -61,16 +61,16 @@ namespace Auvik.Api.Interfaces
 		/// <returns>Task of EntityNotesReadMultiple</returns>
 		[Get("/v1/inventory/entity/note")]
 		Task<EntityNotesReadMultiple> ReadMultipleEntityNote(
-			[AliasAs("filter_entityId")] string filter_entityId = null,
-			[AliasAs("filter_entityType")] string filter_entityType = null,
-			[AliasAs("filter_entityName")] string filter_entityName = null,
-			[AliasAs("filter_lastModifiedBy")] string filter_lastModifiedBy = null,
-			[AliasAs("filter_modifiedAfter")] string filter_modifiedAfter = null,
+			[AliasAs("filter[entityId]")] string filter_entityId = null,
+			[AliasAs("filter[entityType]")] string filter_entityType = null,
+			[AliasAs("filter[entityName]")] string filter_entityName = null,
+			[AliasAs("filter[lastModifiedBy]")] string filter_lastModifiedBy = null,
+			[AliasAs("filter[modifiedAfter]")] string filter_modifiedAfter = null,
 			[AliasAs("tenants")] string tenants = null,
-			[AliasAs("page_first")] decimal? page_first = null,
-			[AliasAs("page_after")] string page_after = null,
-			[AliasAs("page_last")] decimal? page_last = null,
-			[AliasAs("page_before")] string page_before = null,
+			[AliasAs("page[first]")] decimal? page_first = null,
+			[AliasAs("page[after]")] string page_after = null,
+			[AliasAs("page[last]")] decimal? page_last = null,
+			[AliasAs("page[before]")] string page_before = null,
 			CancellationToken? cancellationToken = null
 		);
 

--- a/Auvik.Api/Interfaces/IInterface.cs
+++ b/Auvik.Api/Interfaces/IInterface.cs
@@ -30,16 +30,16 @@ namespace Auvik.Api.Interfaces
 		/// <returns>Task of InterfaceInfoReadMultiple</returns>
 		[Get("/v1/inventory/interface/info")]
 		Task<InterfaceInfoReadMultiple> ReadMultipleInterfaceInfo(
-			[AliasAs("filter_interfaceType")] string filter_interfaceType = null,
-			[AliasAs("filter_parentDevice")] string filter_parentDevice = null,
-			[AliasAs("filter_adminStatus")] bool? filter_adminStatus = null,
-			[AliasAs("filter_operationalStatus")] string filter_operationalStatus = null,
-			[AliasAs("filter_modifiedAfter")] string filter_modifiedAfter = null,
+			[AliasAs("filter[interfaceType]")] string filter_interfaceType = null,
+			[AliasAs("filter[parentDevice]")] string filter_parentDevice = null,
+			[AliasAs("filter[adminStatus]")] bool? filter_adminStatus = null,
+			[AliasAs("filter[operationalStatus]")] string filter_operationalStatus = null,
+			[AliasAs("filter[modifiedAfter]")] string filter_modifiedAfter = null,
 			[AliasAs("tenants")] string tenants = null,
-			[AliasAs("page_first")] decimal? page_first = null,
-			[AliasAs("page_after")] string page_after = null,
-			[AliasAs("page_last")] decimal? page_last = null,
-			[AliasAs("page_before")] string page_before = null,
+			[AliasAs("page[first]")] decimal? page_first = null,
+			[AliasAs("page[after]")] string page_after = null,
+			[AliasAs("page[last]")] decimal? page_last = null,
+			[AliasAs("page[before]")] string page_before = null,
 			CancellationToken? cancellationToken = null
 		);
 

--- a/Auvik.Api/Interfaces/INetwork.cs
+++ b/Auvik.Api/Interfaces/INetwork.cs
@@ -30,16 +30,16 @@ namespace Auvik.Api.Interfaces
 		/// <returns>Task of NetworkDetailsReadMultiple</returns>
 		[Get("/v1/inventory/network/detail")]
 		Task<NetworkDetailsReadMultiple> ReadMultipleNetworkDetails(
-			[AliasAs("filter_networkType")] string filter_networkType = null,
-			[AliasAs("filter_scanStatus")] string filter_scanStatus = null,
-			[AliasAs("filter_devices")] string filter_devices = null,
-			[AliasAs("filter_modifiedAfter")] string filter_modifiedAfter = null,
-			[AliasAs("filter_scope")] string filter_scope = null,
+			[AliasAs("filter[networkType]")] string filter_networkType = null,
+			[AliasAs("filter[scanStatus]")] string filter_scanStatus = null,
+			[AliasAs("filter[devices]")] string filter_devices = null,
+			[AliasAs("filter[modifiedAfter]")] string filter_modifiedAfter = null,
+			[AliasAs("filter[scope]")] string filter_scope = null,
 			[AliasAs("tenants")] string tenants = null,
-			[AliasAs("page_first")] decimal? page_first = null,
-			[AliasAs("page_after")] string page_after = null,
-			[AliasAs("page_last")] decimal? page_last = null,
-			[AliasAs("page_before")] string page_before = null,
+			[AliasAs("page[first]")] decimal? page_first = null,
+			[AliasAs("page[after]")] string page_after = null,
+			[AliasAs("page[last]")] decimal? page_last = null,
+			[AliasAs("page[before]")] string page_before = null,
 			CancellationToken? cancellationToken = null
 		);
 
@@ -64,17 +64,17 @@ namespace Auvik.Api.Interfaces
 		/// <returns>Task of NetworkInfoReadMultiple</returns>
 		[Get("/v1/inventory/network/info")]
 		Task<NetworkInfoReadMultiple> ReadMultipleNetworkInfo(
-			[AliasAs("filter_networkType")] string filter_networkType = null,
-			[AliasAs("filter_scanStatus")] string filter_scanStatus = null,
-			[AliasAs("filter_devices")] string filter_devices = null,
-			[AliasAs("filter_modifiedAfter")] string filter_modifiedAfter = null,
+			[AliasAs("filter[networkType]")] string filter_networkType = null,
+			[AliasAs("filter[scanStatus]")] string filter_scanStatus = null,
+			[AliasAs("filter[devices]")] string filter_devices = null,
+			[AliasAs("filter[modifiedAfter]")] string filter_modifiedAfter = null,
 			[AliasAs("tenants")] string tenants = null,
-			[AliasAs("page_first")] decimal? page_first = null,
-			[AliasAs("page_after")] string page_after = null,
-			[AliasAs("page_last")] decimal? page_last = null,
-			[AliasAs("page_before")] string page_before = null,
+			[AliasAs("page[first]")] decimal? page_first = null,
+			[AliasAs("page[after]")] string page_after = null,
+			[AliasAs("page[last]")] decimal? page_last = null,
+			[AliasAs("page[before]")] string page_before = null,
 			[AliasAs("include")] string include = null,
-			[AliasAs("fields_networkDetail")] string fields_networkDetail = null,
+			[AliasAs("fields[networkDetail]")] string fields_networkDetail = null,
 			CancellationToken? cancellationToken = null
 		);
 
@@ -108,7 +108,7 @@ namespace Auvik.Api.Interfaces
 		Task<NetworkInfoReadSingle> ReadSingleNetworkInfo(
 			[AliasAs("id")] string id,
 			[AliasAs("include")] string include = null,
-			[AliasAs("fields_networkDetail")] string fields_networkDetail = null,
+			[AliasAs("fields[networkDetail]")] string fields_networkDetail = null,
 			CancellationToken? cancellationToken = null
 		);
 	}

--- a/Auvik.Api/Interfaces/IStatistics.cs
+++ b/Auvik.Api/Interfaces/IStatistics.cs
@@ -35,16 +35,16 @@ namespace Auvik.Api.Interfaces
 			[Header("UserAgent")] string userAgent,
 			[AliasAs("componentType")] string componentType,
 			[AliasAs("statId")] string statId,
-			[AliasAs("filter_fromTime")] string filter_fromTime,
-			[AliasAs("filter_interval")] string filter_interval,
-			[AliasAs("filter_thruTime")] string filter_thruTime = null,
-			[AliasAs("filter_componentId")] string filter_componentId = null,
-			[AliasAs("filter_parentDevice")] string filter_parentDevice = null,
+			[AliasAs("filter[fromTime]")] string filter_fromTime,
+			[AliasAs("filter[interval]")] string filter_interval,
+			[AliasAs("filter[thruTime]")] string filter_thruTime = null,
+			[AliasAs("filter[componentId]")] string filter_componentId = null,
+			[AliasAs("filter[parentDevice]")] string filter_parentDevice = null,
 			[AliasAs("tenants")] string tenants = null,
-			[AliasAs("page_first")] decimal? page_first = null,
-			[AliasAs("page_after")] string page_after = null,
-			[AliasAs("page_last")] decimal? page_last = null,
-			[AliasAs("page_before")] string page_before = null,
+			[AliasAs("page[first]")] decimal? page_first = null,
+			[AliasAs("page[after]")] string page_after = null,
+			[AliasAs("page[last]")] decimal? page_last = null,
+			[AliasAs("page[before]")] string page_before = null,
 			CancellationToken? cancellationToken = null
 		);
 
@@ -70,16 +70,16 @@ namespace Auvik.Api.Interfaces
 		[Get("/v1/stat/deviceAvailability/{statId}")]
 		Task<DeviceAvailabilityStatisticsRead> ReadDeviceAvailabilityStatistics(
 			[AliasAs("statId")] string statId,
-			[AliasAs("filter_fromTime")] string filter_fromTime,
-			[AliasAs("filter_interval")] string filter_interval,
-			[AliasAs("filter_thruTime")] string filter_thruTime = null,
-			[AliasAs("filter_deviceType")] string filter_deviceType = null,
-			[AliasAs("filter_deviceId")] string filter_deviceId = null,
+			[AliasAs("filter[fromTime]")] string filter_fromTime,
+			[AliasAs("filter[interval]")] string filter_interval,
+			[AliasAs("filter[thruTime]")] string filter_thruTime = null,
+			[AliasAs("filter[deviceType]")] string filter_deviceType = null,
+			[AliasAs("filter[deviceId]")] string filter_deviceId = null,
 			[AliasAs("tenants")] string tenants = null,
-			[AliasAs("page_first")] decimal? page_first = null,
-			[AliasAs("page_after")] string page_after = null,
-			[AliasAs("page_last")] decimal? page_last = null,
-			[AliasAs("page_before")] string page_before = null,
+			[AliasAs("page[first]")] decimal? page_first = null,
+			[AliasAs("page[after]")] string page_after = null,
+			[AliasAs("page[last]")] decimal? page_last = null,
+			[AliasAs("page[before]")] string page_before = null,
 			CancellationToken? cancellationToken = null
 		);
 
@@ -105,16 +105,16 @@ namespace Auvik.Api.Interfaces
 		[Get("/v1/stat/device/{statId}")]
 		Task<DeviceStatisticsRead> ReadDeviceStatistics(
 			[AliasAs("statId")] string statId,
-			[AliasAs("filter_fromTime")] string filter_fromTime,
-			[AliasAs("filter_interval")] string filter_interval,
-			[AliasAs("filter_thruTime")] string filter_thruTime = null,
-			[AliasAs("filter_deviceType")] string filter_deviceType = null,
-			[AliasAs("filter_deviceId")] string filter_deviceId = null,
+			[AliasAs("filter[fromTime]")] string filter_fromTime,
+			[AliasAs("filter[interval]")] string filter_interval,
+			[AliasAs("filter[thruTime]")] string filter_thruTime = null,
+			[AliasAs("filter[deviceType]")] string filter_deviceType = null,
+			[AliasAs("filter[deviceId]")] string filter_deviceId = null,
 			[AliasAs("tenants")] string tenants = null,
-			[AliasAs("page_first")] decimal? page_first = null,
-			[AliasAs("page_after")] string page_after = null,
-			[AliasAs("page_last")] decimal? page_last = null,
-			[AliasAs("page_before")] string page_before = null,
+			[AliasAs("page[first]")] decimal? page_first = null,
+			[AliasAs("page[after]")] string page_after = null,
+			[AliasAs("page[last]")] decimal? page_last = null,
+			[AliasAs("page[before]")] string page_before = null,
 			CancellationToken? cancellationToken = null
 		);
 
@@ -141,17 +141,17 @@ namespace Auvik.Api.Interfaces
 		[Get("/v1/stat/interface/{statId}")]
 		Task<InterfaceStatisticsRead> ReadInterfaceStatistics(
 			[AliasAs("statId")] string statId,
-			[AliasAs("filter_fromTime")] string filter_fromTime,
-			[AliasAs("filter_interval")] string filter_interval,
-			[AliasAs("filter_thruTime")] string filter_thruTime = null,
-			[AliasAs("filter_interfaceType")] string filter_interfaceType = null,
-			[AliasAs("filter_interfaceId")] string filter_interfaceId = null,
-			[AliasAs("filter_parentDevice")] string filter_parentDevice = null,
+			[AliasAs("filter[fromTime]")] string filter_fromTime,
+			[AliasAs("filter[interval]")] string filter_interval,
+			[AliasAs("filter[thruTime]")] string filter_thruTime = null,
+			[AliasAs("filter[interfaceType]")] string filter_interfaceType = null,
+			[AliasAs("filter[interfaceId]")] string filter_interfaceId = null,
+			[AliasAs("filter[parentDevice]")] string filter_parentDevice = null,
 			[AliasAs("tenants")] string tenants = null,
-			[AliasAs("page_first")] decimal? page_first = null,
-			[AliasAs("page_after")] string page_after = null,
-			[AliasAs("page_last")] decimal? page_last = null,
-			[AliasAs("page_before")] string page_before = null,
+			[AliasAs("page[first]")] decimal? page_first = null,
+			[AliasAs("page[after]")] string page_after = null,
+			[AliasAs("page[last]")] decimal? page_last = null,
+			[AliasAs("page[before]")] string page_before = null,
 			CancellationToken? cancellationToken = null
 		);
 
@@ -175,14 +175,14 @@ namespace Auvik.Api.Interfaces
 		[Get("/v1/stat/oid/{statId}")]
 		Task<DeviceOidMonitorRead> ReadOidStatistics(
 			[AliasAs("statId")] string statId,
-			[AliasAs("filter_deviceId")] string filter_deviceId = null,
-			[AliasAs("filter_deviceType")] string filter_deviceType = null,
-			[AliasAs("filter_oid")] string filter_oid = null,
+			[AliasAs("filter[deviceId]")] string filter_deviceId = null,
+			[AliasAs("filter[deviceType]")] string filter_deviceType = null,
+			[AliasAs("filter[oid]")] string filter_oid = null,
 			[AliasAs("tenants")] string tenants = null,
-			[AliasAs("page_first")] decimal? page_first = null,
-			[AliasAs("page_after")] string page_after = null,
-			[AliasAs("page_last")] decimal? page_last = null,
-			[AliasAs("page_before")] string page_before = null,
+			[AliasAs("page[first]")] decimal? page_first = null,
+			[AliasAs("page[after]")] string page_after = null,
+			[AliasAs("page[last]")] decimal? page_last = null,
+			[AliasAs("page[before]")] string page_before = null,
 			CancellationToken? cancellationToken = null
 		);
 
@@ -208,15 +208,15 @@ namespace Auvik.Api.Interfaces
 		Task<ServiceStatisticsRead> ReadServiceStatistics(
 			[Header("UserAgent")] string userAgent,
 			[AliasAs("statId")] string statId,
-			[AliasAs("filter_fromTime")] string filter_fromTime,
-			[AliasAs("filter_interval")] string filter_interval,
-			[AliasAs("filter_thruTime")] string filter_thruTime = null,
-			[AliasAs("filter_serviceId")] string filter_serviceId = null,
+			[AliasAs("filter[fromTime]")] string filter_fromTime,
+			[AliasAs("filter[interval]")] string filter_interval,
+			[AliasAs("filter[thruTime]")] string filter_thruTime = null,
+			[AliasAs("filter[serviceId]")] string filter_serviceId = null,
 			[AliasAs("tenants")] string tenants = null,
-			[AliasAs("page_first")] decimal? page_first = null,
-			[AliasAs("page_after")] string page_after = null,
-			[AliasAs("page_last")] decimal? page_last = null,
-			[AliasAs("page_before")] string page_before = null,
+			[AliasAs("page[first]")] decimal? page_first = null,
+			[AliasAs("page[after]")] string page_after = null,
+			[AliasAs("page[last]")] decimal? page_last = null,
+			[AliasAs("page[before]")] string page_before = null,
 			CancellationToken? cancellationToken = null
 		);
 	}

--- a/Auvik.Api/Interfaces/ITenants.cs
+++ b/Auvik.Api/Interfaces/ITenants.cs
@@ -36,7 +36,7 @@ namespace Auvik.Api.Interfaces
 		[Get("/v1/tenants/detail")]
 		Task<TenantsDetailReadMultiple> ReadMultipleTenantsDetail(
 			[AliasAs("tenantDomainPrefix")] string tenantDomainPrefix,
-			[AliasAs("filter_availableTenants")] bool? filter_availableTenants = null,
+			[AliasAs("filter[availableTenants]")] bool? filter_availableTenants = null,
 			CancellationToken? cancellationToken = null
 		);
 

--- a/Auvik.Api/Interfaces/IUsage.cs
+++ b/Auvik.Api/Interfaces/IUsage.cs
@@ -23,8 +23,8 @@ namespace Auvik.Api.Interfaces
 		/// <returns>Task of ClientUsageRead</returns>
 		[Get("/v1/billing/usage/client")]
 		Task<ClientUsageRead> ReadClientUsage(
-			[AliasAs("filter_fromDate")] string filter_fromDate,
-			[AliasAs("filter_thruDate")] string filter_thruDate,
+			[AliasAs("filter[fromDate]")] string filter_fromDate,
+			[AliasAs("filter[thruDate]")] string filter_thruDate,
 			[AliasAs("tenants")] string tenants = null,
 			CancellationToken? cancellationToken = null
 		);
@@ -43,8 +43,8 @@ namespace Auvik.Api.Interfaces
 		[Get("/v1/billing/usage/device/{id}")]
 		Task<DeviceUsageRead> ReadDeviceUsage(
 			[AliasAs("id")] string id,
-			[AliasAs("filter_fromDate")] string filter_fromDate,
-			[AliasAs("filter_thruDate")] string filter_thruDate,
+			[AliasAs("filter[fromDate]")] string filter_fromDate,
+			[AliasAs("filter[thruDate]")] string filter_thruDate,
 			CancellationToken? cancellationToken = null
 		);
 	}

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
-	"$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-	"version": "1.2",
-	"publicReleaseRefSpec": [
-		"^refs/heads/main$"
-	]
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "1.3-alpha",
+  "publicReleaseRefSpec": [
+    "^refs/heads/main$"
+  ]
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-	"version": "1.0",
+	"version": "1.2",
 	"publicReleaseRefSpec": [
 		"^refs/heads/main$"
 	]


### PR DESCRIPTION
The parameters like page_after and such need to be sent to Auvik as "page[after]", "page[before]" and the like. Ditto for the named filter parameters. I found this out the hard way when it sent me back the same device query results in an infinite loop for 12 hours. I'm sure Auvik are annoyed with me. :)

I haven't tested every single API, but I did test all the device ones.
