### PR TITLE
LastSupportStatusEnum supports 'unknown' as a value

### DIFF
--- a/Auvik.Api/Data/DeviceLifecycleAttributes.cs
+++ b/Auvik.Api/Data/DeviceLifecycleAttributes.cs
@@ -54,7 +54,13 @@ namespace Auvik.Api.Data
 			/// Enum Empty for "empty"
 			/// </summary>
 			[EnumMember(Value = "empty")]
-			Empty
+			Empty,
+
+			/// <summary>
+			/// Enum Empty for "unknown"
+			/// </summary>
+			[EnumMember(Value = "unknown")]
+			Unknown
 		}
 
 		/// <summary>


### PR DESCRIPTION
I discovered one more "enum" that returns "unknown" as one of its values.